### PR TITLE
Fix: Add max_participants validation on signup

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,13 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    # Validate activity is not full
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is full"
+        )
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}


### PR DESCRIPTION
## 🔧 Fixes Issue #9

This PR implements validation to prevent students from signing up for activities that have reached their maximum capacity.

## Changes Made

- ✅ Added validation check in `signup_for_activity` function
- ✅ Returns HTTP 400 error with "Activity is full" message when capacity is reached
- ✅ Validates participant count **before** adding new student to the list

## Implementation Details

The new validation follows this logic:
```python
# Validate activity is not full
if len(activity["participants"]) >= activity["max_participants"]:
    raise HTTPException(
        status_code=400,
        detail="Activity is full"
    )
```

## Testing

Manual testing can be done by:
1. Finding an activity close to its `max_participants` limit
2. Attempting to register students beyond the limit
3. Verifying that appropriate error is returned

## Benefits

- 🚫 Prevents overcrowding in activities
- 📋 Maintains quality of activities
- 👨‍🏫 Helps teachers manage class sizes effectively
- ⚡ Quick win with high impact

Closes #9